### PR TITLE
Make sure that the task is stopped (by removing the start attribute)

### DIFF
--- a/on-modify.relative-recur
+++ b/on-modify.relative-recur
@@ -33,6 +33,7 @@ modified = json.loads(modified)
 # Has a task with UDA been marked as completed?
 if (UDA_DUE in original or UDA_WAIT in original) and original['status']!='completed' and modified['status']=='completed':
 	del original['modified']
+	del original['start']
 	if UDA_DUE in original:
 		original['due'] = calc(modified['end'] + '+' + original[UDA_DUE])
 	if UDA_WAIT in original:


### PR DESCRIPTION
Hi,

Nice hook!
I made a very simple change in order to make sure that the "new" tasks are always stopped.
I thought I would share it, just in case anyone else in interested (even though this is, as said, a very simple change).
