### PR TITLE
only remove the start attribute if it exists

### DIFF
--- a/on-modify.relative-recur
+++ b/on-modify.relative-recur
@@ -33,7 +33,8 @@ modified = json.loads(modified)
 # Has a task with UDA been marked as completed?
 if (UDA_DUE in original or UDA_WAIT in original) and original['status']!='completed' and modified['status']=='completed':
 	del original['modified']
-	del original['start']
+	if 'start' in original:
+		del original['start']
 	if UDA_DUE in original:
 		original['due'] = calc(modified['end'] + '+' + original[UDA_DUE])
 	if UDA_WAIT in original:


### PR DESCRIPTION
Just noticed that an error is erased if the task is not started. Here's a fix.

Sorry for the inconvenience,
