### PR TITLE
Drop Python2 support

### DIFF
--- a/on-modify.relative-recur
+++ b/on-modify.relative-recur
@@ -1,7 +1,4 @@
-#!/usr/bin/env python
-
-from __future__ import print_function
-from builtins import str
+#!/usr/bin/env python3
 
 import datetime
 import json


### PR DESCRIPTION
Python2 has been dead in upstream for few years and (my) downstream distro won't ship the compat modules anymore. Thanks to the script being adapted, simply drop the compat imports and switch to v3 explicitly.